### PR TITLE
stop trying to ingest /var/log/messages since it no longer exists

### DIFF
--- a/jobs/awslogs-xenial/templates/config/awslogs.conf.erb
+++ b/jobs/awslogs-xenial/templates/config/awslogs.conf.erb
@@ -139,13 +139,6 @@ log_stream_name = {instance_id}
 initial_position = start_of_file
 log_group_name = /var/log/dpkg.log
 
-[/var/log/messages]
-file = /var/log/messages
-buffer_duration = 5000
-log_stream_name = {instance_id}
-initial_position = start_of_file
-log_group_name = /var/log/messages
-
 [/var/log/syslog]
 file = /var/log/syslog
 buffer_duration = 5000


### PR DESCRIPTION
## Changes proposed in this pull request:
- stop attempting to pull in /var/log/messages - I assume this file stopped existing when we switched to xenial, and attempting to locate this file spams our logs with ~700 messages per hour per vm

## security considerations
None