### PR TITLE
Fix to kill all the child processes for the scanner job

### DIFF
--- a/jobs/awslogs-jammy/templates/bin/scanner-ctl
+++ b/jobs/awslogs-jammy/templates/bin/scanner-ctl
@@ -25,6 +25,9 @@ case $1 in
   stop)
     kill_and_wait $PIDFILE
 
+    # ensure all child process are really dead
+    pkill -f "inotify"
+
     ;;
   *)
     echo "Usage: scanner-ctl {start|stop}"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Kill the child processes left behind when monit is shutting down

## security considerations
None, this duplicates the behavior of awslogs-jammy into awslogs-scanner
